### PR TITLE
ephoto: follow upstream migration to meson

### DIFF
--- a/media-gfx/ephoto/ephoto-9999.ebuild
+++ b/media-gfx/ephoto/ephoto-9999.ebuild
@@ -2,11 +2,11 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI="6"
 EFL_USE_GIT="yes"
 EFL_GIT_REPO_CATEGORY="apps"
 E_PKG_IUSE="nls"
-inherit efl
+inherit efl meson
 
 DESCRIPTION="EFL image viewer/editor/manipulator/slideshow creator"
 HOMEPAGE="http://www.enlightenment.org/"
@@ -24,3 +24,7 @@ RDEPEND="
 "
 #	 [thumbnails,xdg]
 DEPEND="${RDEPEND}"
+
+src_configure() {
+	meson_src_configure
+}


### PR DESCRIPTION
Non-meson builds are no longer supported.